### PR TITLE
TASK: ResourceProxyIterators can now be cached

### DIFF
--- a/Classes/Netlogix/JsonApiOrg/Consumer/Domain/Model/ResourceProxy.php
+++ b/Classes/Netlogix/JsonApiOrg/Consumer/Domain/Model/ResourceProxy.php
@@ -18,7 +18,6 @@ class ResourceProxy implements \ArrayAccess
 {
     /**
      * @var ConsumerBackendInterface
-     * @Flow\Inject
      */
     protected $consumerBackend;
 
@@ -32,9 +31,10 @@ class ResourceProxy implements \ArrayAccess
      */
     protected $payload = [];
 
-    public function __construct(Type $type)
+    public function __construct(Type $type, ConsumerBackendInterface $consumerBackend)
     {
         $this->type = $type;
+        $this->consumerBackend = $consumerBackend;
     }
 
     /**

--- a/Classes/Netlogix/JsonApiOrg/Consumer/Domain/Model/ResourceProxyIterator.php
+++ b/Classes/Netlogix/JsonApiOrg/Consumer/Domain/Model/ResourceProxyIterator.php
@@ -3,25 +3,69 @@ declare(strict_types=1);
 
 namespace Netlogix\JsonApiOrg\Consumer\Domain\Model;
 
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Http\Uri;
+
 class ResourceProxyIterator implements \IteratorAggregate, \Countable
 {
+    /**
+     * @var VariableFrontend
+     */
+    protected $cache;
 
     /**
      * @var array<ResourceProxy>
      */
-    protected $data;
+    protected $data = [];
 
     /**
      * @var array
      */
     protected $jsonResult;
 
-    public function __construct(array $data, array $jsonResult = null)
+    /**
+     * @var string
+     */
+    protected $uri;
+
+    protected function __construct(string $uri = '')
     {
-        $this->data = $data;
-        if ($jsonResult !== null) {
-            $this->jsonResult = $jsonResult;
+        $this->uri = $uri;
+    }
+
+    public static function fromUri(Uri $uri): self
+    {
+        return new static((string)$uri);
+    }
+
+    public function injectCacheManager(CacheManager $cacheManager)
+    {
+        $this->cache = $cacheManager->getCache('NetlogixJsonApiOrgConsumer_ResultsCache');
+    }
+
+    public function initialize(callable $convertResourceDefinitionToResourceProxy): self
+    {
+        $result = $this->jsonResult ?? [];
+
+        $this->data = array_map($convertResourceDefinitionToResourceProxy, $result['data']);
+        array_map($convertResourceDefinitionToResourceProxy, $result['included']);
+
+        return $this;
+    }
+
+    public function withJsonResult(array $jsonResult): self
+    {
+        $jsonResult['data'] = $jsonResult['data'] ?? [];
+        if (isset($jsonResult['data']['type']) && isset($jsonResult['data']['id'])) {
+            $jsonResult['data'] = [$jsonResult['data']];
         }
+        $jsonResult['included'] = $jsonResult['included'] ?? [];
+
+        $new = new static($this->uri);
+        $new->setRawJson($jsonResult);
+
+        return $new;
     }
 
     /**
@@ -30,6 +74,11 @@ class ResourceProxyIterator implements \IteratorAggregate, \Countable
     public function getIterator()
     {
         yield from $this->data;
+    }
+
+    public function getArrayCopy(): array
+    {
+        return iterator_to_array($this, false);
     }
 
     /**
@@ -52,4 +101,30 @@ class ResourceProxyIterator implements \IteratorAggregate, \Countable
         return $this->jsonResult['links'] ?? [];
     }
 
+    public function hasResults(): bool
+    {
+        return is_array($this->jsonResult);
+    }
+
+    public function saveToCache(int $lifetime, string ...$tags): self
+    {
+        $identifier = sha1($this->uri);
+        $this->cache->set($identifier, $this->jsonResult, $tags, $lifetime);
+        return $this;
+    }
+
+    public function loadFromCache(): self
+    {
+        $identifier = sha1($this->uri);
+        $jsonResult = $this->cache->get($identifier);
+        $this->jsonResult = $jsonResult !== false ? $jsonResult : null;
+        return $this;
+    }
+
+    protected function setRawJson(array $jsonResult): self
+    {
+        $this->jsonResult = $jsonResult;
+        $this->data = [];
+        return $this;
+    }
 }

--- a/Classes/Netlogix/JsonApiOrg/Consumer/Domain/Model/Type.php
+++ b/Classes/Netlogix/JsonApiOrg/Consumer/Domain/Model/Type.php
@@ -10,7 +10,9 @@ namespace Netlogix\JsonApiOrg\Consumer\Domain\Model;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Uri;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 class Type
 {
@@ -65,6 +67,12 @@ class Type
     protected $defaultIncludes = [];
 
     /**
+     * @var ObjectManagerInterface
+     * @Flow\Inject
+     */
+    protected $objectgManager;
+
+    /**
      * @param string $typeName
      * @param string $resourceClassName
      * @param array $properties
@@ -117,6 +125,14 @@ class Type
     public function getResourceClassName()
     {
         return $this->resourceClassName;
+    }
+
+    /**
+     * @return ResourceProxy
+     */
+    public function createEmptyResource(): ResourceProxy
+    {
+        return $this->objectgManager->get($this->resourceClassName, $this);
     }
 
     /**

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,3 +1,7 @@
 NetlogixJsonApiOrgConsumer_RequestsCache:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\TransientMemoryBackend
+
+NetlogixJsonApiOrgConsumer_ResultsCache:
+    frontend: Neos\Cache\Frontend\VariableFrontend
+    backend: Neos\Cache\Backend\FileBackend

--- a/Configuration/Testing/Caches.yaml
+++ b/Configuration/Testing/Caches.yaml
@@ -1,0 +1,3 @@
+NetlogixJsonApiOrgConsumer_ResultsCache:
+    backend: Neos\Cache\Backend\FileBackend
+    backendOptions: []

--- a/Tests/Functional/CachingTest.php
+++ b/Tests/Functional/CachingTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Tests\Functional;
+
+use Netlogix\JsonApiOrg\Consumer\Domain\Model as JsonApi;
+
+class CachingTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     * @dataProvider provideJsonResponse
+     */
+    public function JSON_data_can_be_saved_to_cache(array $jsonApiFixture)
+    {
+        $uri = $this->asDataUri([]);
+
+        JsonApi\ResourceProxyIterator::fromUri($uri)
+            ->withJsonResult($jsonApiFixture)
+            ->saveToCache(1000);
+
+        $result = $this->consumerBackend
+            ->fetchFromUri($uri)
+            ->getArrayCopy();
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(JsonApi\ResourceProxy::class, current($result));
+    }
+
+    /**
+     * @test
+     * @dataProvider provideJsonResponse
+     */
+    public function Cached_data_respects_cache_lifetime(array $jsonApiFixture)
+    {
+        $uri = $this->asDataUri([]);
+
+        JsonApi\ResourceProxyIterator::fromUri($uri)
+            ->withJsonResult($jsonApiFixture)
+            ->saveToCache(1);
+
+        sleep(2);
+
+        $result = $this->consumerBackend
+            ->fetchFromUri($uri)
+            ->getArrayCopy();
+
+        $this->assertCount(0, $result);
+    }
+}

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Tests\Functional;
+
+use Neos\Flow\Http\Uri;
+use Neos\Flow\Tests\FunctionalTestCase as BaseTestCase;
+use Netlogix\JsonApiOrg\Consumer\Domain\Model as JsonApi;
+use Netlogix\JsonApiOrg\Consumer\Service\ConsumerBackend;
+
+class FunctionalTestCase extends BaseTestCase
+{
+    const TYPE_NAME = 'some/type';
+
+    /**
+     * @var JsonApi\Type
+     */
+    protected $type;
+
+    /**
+     * @var ConsumerBackend
+     */
+    protected $consumerBackend;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $typeName = self::TYPE_NAME;
+        $className = JsonApi\ResourceProxy::class;
+        $properties = [
+            'attr' => JsonApi\Type::PROPERTY_ATTRIBUTE,
+            'single' => JsonApi\Type::PROPERTY_SINGLE_RELATIONSHIP,
+            'collection' => JsonApi\Type::PROPERTY_COLLECTION_RELATIONSHIP,
+        ];
+
+        $this->type = new class ($typeName, $className, $properties) extends JsonApi\Type {
+            public $__consumerBackend;
+
+            public function createEmptyResource(): JsonApi\ResourceProxy
+            {
+                return new class ($this, $this->__consumerBackend) extends JsonApi\ResourceProxy {
+                };
+            }
+        };
+
+        $this->consumerBackend = new ConsumerBackend();
+        $this->consumerBackend->addType($this->type);
+        $this->type->__consumerBackend = $this->consumerBackend;
+    }
+
+    public function asDataUri(array $fixture): Uri
+    {
+        $dataUri = 'data:application/json;base64,' . base64_encode(json_encode($fixture));
+        return new Uri($dataUri);
+    }
+
+    public function provideJsonResponse()
+    {
+        $entity = [
+            'id' => 0,
+            'type' => self::TYPE_NAME
+        ];
+
+        $singleObjectResult = [
+            'data' => $entity
+        ];
+        yield 'single related object' => [$singleObjectResult];
+
+        $collectionOfObjects = [
+            'data' => [$entity]
+        ];
+        yield 'collection of related objects' => [$collectionOfObjects];
+    }
+}

--- a/Tests/Functional/MappingTest.php
+++ b/Tests/Functional/MappingTest.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Tests\Functional;
+
+use Netlogix\JsonApiOrg\Consumer\Domain\Model as JsonApi;
+
+class MappingTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     * @dataProvider provideJsonResponse
+     */
+    public function JSON_data_can_be_transformed_into_ResourceProxy_objects(array $jsonApiFixture)
+    {
+        $uri = self::asDataUri(
+            $jsonApiFixture
+        );
+
+        $result = $this->consumerBackend
+            ->fetchFromUri($uri)
+            ->getArrayCopy();
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(JsonApi\ResourceProxy::class, current($result));
+    }
+
+    /**
+     * @test
+     */
+    public function ResourceProxy_objects_can_have_attributes()
+    {
+        $jsonApiFixture = [
+            'data' => [
+                'type' => self::TYPE_NAME,
+                'id' => 1,
+                'attributes' => [
+                    'attr' => 'attribute value'
+                ]
+            ]
+        ];
+
+        $uri = self::asDataUri([]);
+
+        JsonApi\ResourceProxyIterator::fromUri($uri)
+            ->withJsonResult($jsonApiFixture)
+            ->saveToCache(100);
+
+        $result = $this->consumerBackend
+            ->fetchFromUri($uri)
+            ->getIterator()
+            ->current();
+
+        assert($result instanceof JsonApi\ResourceProxy);
+        $this->assertEquals('attribute value', $result->offsetGet('attr'));
+    }
+
+    /**
+     * @test
+     */
+    public function ResourceProxy_objects_can_have_relations_of_type_single()
+    {
+        $second = [
+            'type' => self::TYPE_NAME,
+            'id' => 2,
+        ];
+
+        $jsonApiFixture = [
+            'data' => [
+                'type' => self::TYPE_NAME,
+                'id' => 1,
+                'relationships' => [
+                    'single' => [
+                        'data' => $second
+                    ]
+                ]
+            ],
+            'included' => [
+                $second
+            ]
+        ];
+
+        $uri = self::asDataUri([]);
+
+        JsonApi\ResourceProxyIterator::fromUri($uri)
+            ->withJsonResult($jsonApiFixture)
+            ->saveToCache(100);
+
+        $result = $this->consumerBackend
+            ->fetchFromUri($uri)
+            ->getIterator()
+            ->current();
+
+        assert($result instanceof JsonApi\ResourceProxy);
+        $this->assertInstanceOf(JsonApi\ResourceProxy::class, $result->offsetGet('single'));
+    }
+
+    /**
+     * @test
+     */
+    public function ResourceProxy_objects_can_have_relations_of_type_collection()
+    {
+        $second = [
+            'type' => self::TYPE_NAME,
+            'id' => 2,
+        ];
+        $third = [
+            'type' => self::TYPE_NAME,
+            'id' => 3,
+        ];
+
+        $jsonApiFixture = [
+            'data' => [
+                'type' => self::TYPE_NAME,
+                'id' => 1,
+                'relationships' => [
+                    'collection' => [
+                        'data' => [
+                            $second,
+                            $third,
+                        ]
+                    ]
+                ]
+            ],
+            'included' => [
+                $second,
+                $third,
+            ]
+        ];
+
+        $uri = self::asDataUri([]);
+
+        JsonApi\ResourceProxyIterator::fromUri($uri)
+            ->withJsonResult($jsonApiFixture)
+            ->saveToCache(100);
+
+        $result = $this->consumerBackend
+            ->fetchFromUri($uri)
+            ->getIterator()
+            ->current();
+
+        assert($result instanceof JsonApi\ResourceProxy);
+
+        $collection = $result->offsetGet('collection');
+        $this->assertCount(2, $collection);
+        foreach ($collection as $related) {
+            $this->assertInstanceOf(JsonApi\ResourceProxy::class, $related);
+        }
+    }
+}


### PR DESCRIPTION
The ResourceProxyIteterator object can now be cached using the
request uri as cache identifier.

Fetching data from an upstream server always asks this cache to avoid
HTTP requests.
Adding the response to that cache must be done manually because lifetime
and tags can only be determined by looking at the response data.

This introduces the public method ResourceProxyIterator::saveToCache()
which is meant as public API.

Related: ADIGITAL-2387