### PR TITLE
BUGFIX: Expect $uri->getPath() to return null in EndpointCacheMiddleware

### DIFF
--- a/Classes/Guzzle/Middleware/EndpointCacheMiddleware.php
+++ b/Classes/Guzzle/Middleware/EndpointCacheMiddleware.php
@@ -31,7 +31,8 @@ class EndpointCacheMiddleware
                 return $handler($request, $options);
             }
 
-            if (!self::str_ends_with(rtrim($request->getUri()->getPath(), '/'), '/.well-known/endpoint-discovery')) {
+            $requestPath = $request->getUri()->getPath() ?? '';
+            if (!self::str_ends_with(rtrim($requestPath, '/'), '/.well-known/endpoint-discovery')) {
                 return $handler($request, $options);
             }
 

--- a/Tests/Unit/Guzzle/Middleware/EndpointCacheMiddlewareTest.php
+++ b/Tests/Unit/Guzzle/Middleware/EndpointCacheMiddlewareTest.php
@@ -71,6 +71,27 @@ class EndpointCacheMiddlewareTest extends UnitTestCase
     /**
      * @test
      */
+    public function Empty_paths_dont_cause_exception()
+    {
+        $uri = new \Neos\Flow\Http\Uri('https://foo');
+        $request = new Request('GET', $uri);
+
+        $this->assertNull($uri->getPath());
+
+        $options = [];
+
+        $mock = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $mock->expects($this->once())
+            ->method('__invoke')
+            ->with($request, $options);
+
+        $middleware = $this->middleware->__invoke(\Closure::fromCallable($mock));
+        $middleware($request, $options);
+    }
+
+    /**
+     * @test
+     */
     public function Endpoint_discovery_result_is_written_to_cache()
     {
         $request = new Request('GET', '/foo/.well-known/endpoint-discovery');


### PR DESCRIPTION
Flow's Uri implementation may return null for empty paths