### PR TITLE
feat: Introduce parallel fetch requests

### DIFF
--- a/Classes/Guzzle/CurlMultiHandlerClientProvider.php
+++ b/Classes/Guzzle/CurlMultiHandlerClientProvider.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Guzzle;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\HandlerStack;
+use Netlogix\JsonApiOrg\Consumer\Guzzle\Middleware\EndpointCacheMiddleware;
+
+final class CurlMultiHandlerClientProvider implements ClientProvider
+{
+    public ?Client $client = null;
+
+    public function createClient(): Client
+    {
+        if ($this->client === null) {
+            $handler = new CurlMultiHandler();
+            $stack = HandlerStack::create($handler);
+            $stack->push(new EndpointCacheMiddleware(), 'endpoint-cache');
+            $this->client = new Client(['handler' => $stack]);
+        }
+        return $this->client;
+    }
+
+}

--- a/Classes/Service/ConsumerBackendInterface.php
+++ b/Classes/Service/ConsumerBackendInterface.php
@@ -10,6 +10,7 @@ namespace Netlogix\JsonApiOrg\Consumer\Service;
  * source code.
  */
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Netlogix\JsonApiOrg\Consumer\Domain\Model\Arguments\PageInterface;
 use Netlogix\JsonApiOrg\Consumer\Domain\Model\Arguments\SortInterface;
 use Netlogix\JsonApiOrg\Consumer\Domain\Model\ResourceProxy;
@@ -46,10 +47,22 @@ interface ConsumerBackendInterface
     public function findByTypeAndFilter($type, $filter = [], $include = [], PageInterface $page = null, SortInterface $sort = null);
 
     /**
+     * Fetch data from the given URI synchronously.
+     * The resulting ResourceProxyIterator is fully populated.
+     *
      * @param UriInterface $queryUri
      * @return ResourceProxyIterator
      */
     public function fetchFromUri(UriInterface $queryUri);
+
+    /**
+     * Fetch data from the given URI asynchronously.
+     * The request will be executed immediately.
+     *
+     * @param UriInterface $queryUri
+     * @return PromiseInterface<ResourceProxyIterator>
+     */
+    public function requestFromUri(UriInterface $queryUri): PromiseInterface;
 
     /**
      * @param mixed $type


### PR DESCRIPTION
* Add multi guzzle based client
* Introduce `ConsumerBackend::requestFromUri(): PromiseInterface`
* Switch internals from `ConsumerBackend` to make use of `requestFromUri()`