### PR TITLE
fix: Handling of no-store was flipped

### DIFF
--- a/Classes/Service/ConsumerBackend.php
+++ b/Classes/Service/ConsumerBackend.php
@@ -280,7 +280,7 @@ class ConsumerBackend implements ConsumerBackendInterface
             $response = $this
                 ->fetch($uri, $headers)
                 ->then(function(string $result) use ($cacheIdentifier, $storeResponse) {
-                    if (!$storeResponse) {
+                    if ($storeResponse) {
                         $this->requestsCache->set($cacheIdentifier, $result);
                     }
                     return $result;


### PR DESCRIPTION
The internal state variable of $storeResponse was calculated correctly, but the response got stored to cachen when $storeResponse===false.

Related: VCLOUD-513