### PR TITLE
feat: Map response error status codes to specific exception classes

### DIFF
--- a/Classes/Exception/Client/BadRequest.php
+++ b/Classes/Exception/Client/BadRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class BadRequest extends ClientException
+{
+    public const STATUS_CODE = 400;
+}

--- a/Classes/Exception/Client/ClientException.php
+++ b/Classes/Exception/Client/ClientException.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use GuzzleHttp\Exception\ClientException as GuzzleClientException;
+use Neos\Flow\Annotations as Flow;
+use Psr\Http\Message\RequestInterface;
+use Throwable;
+
+/**
+ * @Flow\Proxy(false))
+ */
+abstract class ClientException extends GuzzleClientException
+{
+    public static function wrapException(RequestInterface $request, Throwable $e): GuzzleClientException
+    {
+        $exception = parent::wrapException($request, $e);
+        return match ($exception->getResponse()->getStatusCode()) {
+            BadRequest::STATUS_CODE => new BadRequest(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            Unauthorized::STATUS_CODE => new Unauthorized(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            Forbidden::STATUS_CODE => new Forbidden(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            NotFound::STATUS_CODE => new NotFound(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            MethodNotAllowed::STATUS_CODE => new MethodNotAllowed(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            NotAcceptable::STATUS_CODE => new NotAcceptable(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            RequestTimeout::STATUS_CODE => new RequestTimeout(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            default => $exception
+        };
+    }
+}

--- a/Classes/Exception/Client/Forbidden.php
+++ b/Classes/Exception/Client/Forbidden.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class Forbidden extends ClientException
+{
+    public const STATUS_CODE = 403;
+}

--- a/Classes/Exception/Client/MethodNotAllowed.php
+++ b/Classes/Exception/Client/MethodNotAllowed.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class MethodNotAllowed extends ClientException
+{
+    public const STATUS_CODE = 405;
+}

--- a/Classes/Exception/Client/NotAcceptable.php
+++ b/Classes/Exception/Client/NotAcceptable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class NotAcceptable extends ClientException
+{
+    public const STATUS_CODE = 406;
+}

--- a/Classes/Exception/Client/NotFound.php
+++ b/Classes/Exception/Client/NotFound.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class NotFound extends ClientException
+{
+    public const STATUS_CODE = 404;
+}

--- a/Classes/Exception/Client/RequestTimeout.php
+++ b/Classes/Exception/Client/RequestTimeout.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class RequestTimeout extends ClientException
+{
+    public const STATUS_CODE = 408;
+}

--- a/Classes/Exception/Client/Unauthorized.php
+++ b/Classes/Exception/Client/Unauthorized.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Client;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class Unauthorized extends ClientException
+{
+    public const STATUS_CODE = 401;
+}

--- a/Classes/Exception/Server/BadGateway.php
+++ b/Classes/Exception/Server/BadGateway.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Server;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class BadGateway extends ServerException
+{
+    public const STATUS_CODE = 502;
+}

--- a/Classes/Exception/Server/GatewayTimeout.php
+++ b/Classes/Exception/Server/GatewayTimeout.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Server;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class GatewayTimeout extends ServerException
+{
+    public const STATUS_CODE = 504;
+}

--- a/Classes/Exception/Server/InternalServerError.php
+++ b/Classes/Exception/Server/InternalServerError.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Server;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class InternalServerError extends ServerException
+{
+    public const STATUS_CODE = 500;
+}

--- a/Classes/Exception/Server/ServerException.php
+++ b/Classes/Exception/Server/ServerException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Server;
+
+use GuzzleHttp\Exception\ServerException as GuzzleServerException;
+use Neos\Flow\Annotations as Flow;
+use Psr\Http\Message\RequestInterface;
+use Throwable;
+
+/**
+ * @Flow\Proxy(false))
+ */
+abstract class ServerException extends GuzzleServerException
+{
+    public static function wrapException(RequestInterface $request, Throwable $e): GuzzleServerException
+    {
+        $exception = parent::wrapException($request, $e);
+        return match ($exception->getResponse()->getStatusCode()) {
+            BadGateway::STATUS_CODE => new BadGateway(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            ServiceUnavailable::STATUS_CODE => new ServiceUnavailable(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            GatewayTimeout::STATUS_CODE => new GatewayTimeout(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            InternalServerError::STATUS_CODE => new InternalServerError(
+                $exception->getMessage(),
+                $exception->getRequest(),
+                $exception->getResponse(),
+                $exception->getPrevious(),
+                $exception->getHandlerContext()
+            ),
+            default => $exception
+        };
+    }
+}

--- a/Classes/Exception/Server/ServiceUnavailable.php
+++ b/Classes/Exception/Server/ServiceUnavailable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Exception\Server;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Proxy(false))
+ */
+final class ServiceUnavailable extends ServerException
+{
+    public const STATUS_CODE = 503;
+}

--- a/Tests/Functional/ExceptionMappingTest.php
+++ b/Tests/Functional/ExceptionMappingTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\JsonApiOrg\Consumer\Tests\Functional;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
+use Netlogix\JsonApiOrg\Consumer\Exception;
+use Netlogix\JsonApiOrg\Consumer\Tests\Common\Guzzle\TestingClientProvider;
+
+class ExceptionMappingTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     * @dataProvider provideClientException
+     * @dataProvider provideServerException
+     */
+    public function HTTP_response_error_status_codes_result_in_individual_exception_classes(
+        int $statusCode,
+        string $exceptionClassName
+    ) {
+        $uri = new Uri('https://127.0.0.1');
+
+        $restingClientProvider = $this->objectManager->get(TestingClientProvider::class);
+        $restingClientProvider->queueResponse(
+            $uri,
+            new Response($statusCode)
+        );
+
+        $this->expectException($exceptionClassName);
+
+        $this->consumerBackend
+            ->fetchFromUri($uri);
+    }
+
+    public static function provideClientException()
+    {
+        yield Exception\Client\BadRequest::class => [
+            'statusCode' => Exception\Client\BadRequest::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\BadRequest::class,
+        ];
+
+        yield Exception\Client\Forbidden::class => [
+            'statusCode' => Exception\Client\Forbidden::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\Forbidden::class,
+        ];
+
+        yield Exception\Client\MethodNotAllowed::class => [
+            'statusCode' => Exception\Client\MethodNotAllowed::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\MethodNotAllowed::class,
+        ];
+
+        yield Exception\Client\NotAcceptable::class => [
+            'statusCode' => Exception\Client\NotAcceptable::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\NotAcceptable::class,
+        ];
+
+        yield Exception\Client\NotFound::class => [
+            'statusCode' => Exception\Client\NotFound::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\NotFound::class,
+        ];
+
+        yield Exception\Client\RequestTimeout::class => [
+            'statusCode' => Exception\Client\RequestTimeout::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\RequestTimeout::class,
+        ];
+
+        yield Exception\Client\Unauthorized::class => [
+            'statusCode' => Exception\Client\Unauthorized::STATUS_CODE,
+            'exceptionClassName' => Exception\Client\Unauthorized::class,
+        ];
+    }
+
+    public static function provideServerException()
+    {
+        yield Exception\Server\InternalServerError::class => [
+            'statusCode' => Exception\Server\InternalServerError::STATUS_CODE,
+            'exceptionClassName' => Exception\Server\InternalServerError::class,
+        ];
+
+        yield Exception\Server\BadGateway::class => [
+            'statusCode' => Exception\Server\BadGateway::STATUS_CODE,
+            'exceptionClassName' => Exception\Server\BadGateway::class,
+        ];
+
+        yield Exception\Server\GatewayTimeout::class => [
+            'statusCode' => Exception\Server\GatewayTimeout::STATUS_CODE,
+            'exceptionClassName' => Exception\Server\GatewayTimeout::class,
+        ];
+
+        yield Exception\Server\ServiceUnavailable::class => [
+            'statusCode' => Exception\Server\ServiceUnavailable::STATUS_CODE,
+            'exceptionClassName' => Exception\Server\ServiceUnavailable::class,
+        ];
+    }
+}


### PR DESCRIPTION
Guzzle throws generic ClientException instances for HTTP 4xx responses and generic ServerException instances for HTTP 5xx responses.

In some cases, the consuming application may need to handle errors differently depending on the exact status code. For example, responses with status code 504 ("Gateway Timeout") often occur when a web server closes the client connection before the application server finishes processing. In such cases, retrying the request might succeed, especially if the initial request primed relevant caches.

To allow for fine-grained error handling using try/catch blocks, individual status codes are now mapped to dedicated exception classes.